### PR TITLE
Add cat command

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is a **Kotlin-based shell emulator** designed to mimic a session in
 ## Features
 
 - Simulates a command-line shell environment.
-- Supports executing commands like `ls`, `cd`, `exit`, `wc`, `history`, and `uptime`.
+- Supports executing commands like `ls`, `cd`, `exit`, `wc`, `cat`, `history`, and `uptime`.
 - Accepts a virtual file system in the form of a `.tar` file.
 - Tracks the uptime since the emulator was started.
 - Records and displays command history.
@@ -40,11 +40,15 @@ The emulator supports the following commands:
    - Displays the word count of the specified file.
    - Usage: `wc <file>`
 
-5. **`history`**:
+5. **`cat <file>`**:
+   - Outputs the contents of the specified file.
+   - Usage: `cat <file>`
+
+6. **`history`**:
    - Displays the history of commands executed in the current session.
    - Usage: `history`
 
-6. **`uptime`**:
+7. **`uptime`**:
    - Displays the amount of time the emulator has been running since startup.
    - Usage: `uptime`
 

--- a/src/main/kotlin/com/yandexbrouser/kotlinshell/commands/CatCommand.kt
+++ b/src/main/kotlin/com/yandexbrouser/kotlinshell/commands/CatCommand.kt
@@ -1,0 +1,15 @@
+package com.yandexbrouser.kotlinshell.commands
+
+import com.yandexbrouser.kotlinshell.filesystem.VirtualFileSystem
+
+class CatCommand(private val fileSystem: VirtualFileSystem) : Command {
+  override fun execute(args: List<String>): String {
+    if (args.isEmpty()) {
+      return "No file specified."
+    }
+
+    val fileName = args[0]
+    val content = fileSystem.readFileContent(fileName)
+    return content ?: "File not found: $fileName"
+  }
+}

--- a/src/main/kotlin/com/yandexbrouser/kotlinshell/commands/CommandHandler.kt
+++ b/src/main/kotlin/com/yandexbrouser/kotlinshell/commands/CommandHandler.kt
@@ -2,6 +2,9 @@ package com.yandexbrouser.kotlinshell.commands
 
 import com.yandexbrouser.kotlinshell.filesystem.VirtualFileSystem
 
+// Newly added command
+import com.yandexbrouser.kotlinshell.commands.CatCommand
+
 class CommandHandler(private val virtualFileSystem: VirtualFileSystem) {
   private val history = mutableListOf<String>()
   private val startTime = System.currentTimeMillis()
@@ -18,6 +21,7 @@ class CommandHandler(private val virtualFileSystem: VirtualFileSystem) {
       "cd" -> CdCommand(virtualFileSystem).execute(args)
       "exit" -> ExitCommand().execute(args)
       "wc" -> WcCommand(virtualFileSystem).execute(args)
+      "cat" -> CatCommand(virtualFileSystem).execute(args)
       "history" -> HistoryCommand(history).execute(args)
       "uptime" -> UptimeCommand(startTime).execute(args)
       else -> "Unknown command: $commandName"

--- a/src/test/kotlin/com/yandexbrouser/kotlinshell/commands/CommandTests.kt
+++ b/src/test/kotlin/com/yandexbrouser/kotlinshell/commands/CommandTests.kt
@@ -3,6 +3,7 @@ package com.yandexbrouser.kotlinshell.commands
 import com.yandexbrouser.kotlinshell.createTestTarFile
 import com.yandexbrouser.kotlinshell.deleteTestFile
 import com.yandexbrouser.kotlinshell.filesystem.VirtualFileSystem
+import com.yandexbrouser.kotlinshell.commands.CatCommand
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -135,6 +136,32 @@ class CommandTests {
     val result = wcCommand.execute(listOf("nonexistent.txt"))
 
     assertEquals("File not found: nonexistent.txt", result)
+
+    deleteTestFile(tarFile)
+  }
+
+  @Test
+  fun `should display file contents with cat`() {
+    val tarFile = createTestTarFile(listOf("file1.txt" to "Hello"))
+    val fileSystem = VirtualFileSystem(tarFile.absolutePath)
+
+    val catCommand = CatCommand(fileSystem)
+    val result = catCommand.execute(listOf("file1.txt"))
+
+    assertEquals("Hello", result)
+
+    deleteTestFile(tarFile)
+  }
+
+  @Test
+  fun `should handle non-existent file for cat command`() {
+    val tarFile = createTestTarFile(listOf("file1.txt" to "Content"))
+    val fileSystem = VirtualFileSystem(tarFile.absolutePath)
+
+    val catCommand = CatCommand(fileSystem)
+    val result = catCommand.execute(listOf("missing.txt"))
+
+    assertEquals("File not found: missing.txt", result)
 
     deleteTestFile(tarFile)
   }


### PR DESCRIPTION
## Summary
- add `CatCommand` for printing file contents
- wire `cat` command into `CommandHandler`
- document `cat` command in README
- test `cat` command functionality

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_683f48bc5960832a97fbea1882f79b7b